### PR TITLE
Blast API setup parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.sailthru.client</groupId>
   <artifactId>sailthru-java-client</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>sailthru-java-client</name>

--- a/src/main/com/sailthru/client/params/Blast.java
+++ b/src/main/com/sailthru/client/params/Blast.java
@@ -38,6 +38,7 @@ public class Blast extends AbstractApiParams implements ApiParams {
     protected Integer abtest;
     protected Integer test_percent;
     protected String data_feed_url;
+    protected String setup;
 
     public Blast(String name, String list, String scheduleTime, String fromName, String fromEmail, String subject, String contentHtml, String contentText) {
         this.name = name;
@@ -180,6 +181,11 @@ public class Blast extends AbstractApiParams implements ApiParams {
         return this;
     }
 
+    public Blast assignSetup(String setup) {
+      this.setup = setup;
+      return this;
+    }
+
     public Type getType() {
         Type type = new TypeToken<Blast>() {}.getType();
         return type;
@@ -187,6 +193,6 @@ public class Blast extends AbstractApiParams implements ApiParams {
     
     @Override
     public ApiAction getApiCall() {
-        return ApiAction.alert;
+        return ApiAction.blast;
     }
 }


### PR DESCRIPTION
these changes have not fully been tested and are very minor.  i am receiving the following error for a ClassCastException for the response.  didn't dig into this error yet as ben asked me to submit what i had at this point and he could take it from there

the version number will help people out as well.  ensure anyone using the library knows which version they are on

java.lang.ClassCastException: com.sailthru.client.handler.response.JsonResponse cannot be cast to java.util.Map
    at com.sailthru.client.SailthruClient.scheduleBlast(SailthruClient.java:165)
    at .<init>(<console>:25)
    at .<clinit>(<console>)
    at .<init>(<console>:11)
    at .<clinit>(<console>)
    at $print(<console>)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:704)
    at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:914)
    at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:546)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:577)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:543)
    at scala.tools.nsc.interpreter.ILoop.reallyInterpret$1(ILoop.scala:694)
    at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:745)
    at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:651)
    at scala.tools.nsc.interpreter.ILoop.processLine$1(ILoop.scala:542)
    at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:550)
    at scala.tools.nsc.interpreter.ILoop.process(ILoop.scala:822)
    at scala.tools.nsc.interpreter.ILoop.main(ILoop.scala:851)
    at xsbt.ConsoleInterface.run(ConsoleInterface.scala:57)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:57)
    at sbt.compiler.AnalyzingCompiler.console(AnalyzingCompiler.scala:48)
    at sbt.Console.console0$1(Console.scala:23)
    at sbt.Console$$anonfun$apply$2$$anonfun$apply$1.apply$mcV$sp(Console.scala:24)
    at sbt.TrapExit$.executeMain$1(TrapExit.scala:33)
    at sbt.TrapExit$$anon$1.run(TrapExit.scala:42)
