### PR TITLE
bugzid 9279: fixing an NPE in java client

### DIFF
--- a/src/main/com/sailthru/client/exceptions/ResourceNotFoundException.java
+++ b/src/main/com/sailthru/client/exceptions/ResourceNotFoundException.java
@@ -1,11 +1,14 @@
 package com.sailthru.client.exceptions;
 
+import java.util.Map;
+
 /**
  *
  * @author Prajwal Tuladhar <praj@sailthru.com>
  */
 public class ResourceNotFoundException extends ApiException {
-    public ResourceNotFoundException(int statusCode, String reason, Object jsonResponse) {
+    public ResourceNotFoundException(int statusCode, String reason,
+            Map<String, Object> jsonResponse) {
         super(statusCode, reason, jsonResponse);
     }
 }

--- a/src/main/com/sailthru/client/exceptions/UnAuthorizedException.java
+++ b/src/main/com/sailthru/client/exceptions/UnAuthorizedException.java
@@ -1,11 +1,13 @@
 package com.sailthru.client.exceptions;
 
+import java.util.Map;
+
 /**
  *
  * @author Prajwal Tuladhar <praj@sailthru.com>
  */
 public class UnAuthorizedException extends ApiException {
-    public UnAuthorizedException(int statusCode, String reason, Object jsonResponse) {
+    public UnAuthorizedException(int statusCode, String reason, Map<String, Object> jsonResponse) {
         super(statusCode, reason, jsonResponse);
     }
 }


### PR DESCRIPTION
Fix for the following NPE:

java.lang.NullPointerException: null
    at com.sailthru.client.exceptions.ApiException.create(ApiException.java:38)
    at com.sailthru.client.http.SailthruHandler.handleResponse(SailthruHandler.java:70)
    at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:945)
    at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:919)
    at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:910)
