### PR TITLE
Updated test class date format to UTC

### DIFF
--- a/src/test/com/sailthru/client/params/ContentTest.java
+++ b/src/test/com/sailthru/client/params/ContentTest.java
@@ -2,12 +2,16 @@ package com.sailthru.client.params;
 
 import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
+
 import junit.framework.TestCase;
 
-import java.util.*;
-import java.util.List;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
 
-import java.text.*;
 
 public class ContentTest extends TestCase {
     Gson gson = SailthruUtil.createGson();

--- a/src/test/com/sailthru/client/params/PurchaseTest.java
+++ b/src/test/com/sailthru/client/params/PurchaseTest.java
@@ -2,8 +2,11 @@ package com.sailthru.client.params;
 
 import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
+
 import junit.framework.TestCase;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +14,7 @@ import java.util.List;
 import java.util.Date;
 import java.util.TimeZone;
 
-import java.text.*;
+
 
 public class PurchaseTest extends TestCase {
     Gson gson = SailthruUtil.createGson();

--- a/src/test/com/sailthru/client/params/SendTest.java
+++ b/src/test/com/sailthru/client/params/SendTest.java
@@ -26,13 +26,15 @@ package com.sailthru.client.params;
 import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+
 import junit.framework.TestCase;
 
-import java.text.*;
 
 public class SendTest extends TestCase {
     private Gson gson = SailthruUtil.createGson();
@@ -131,9 +133,8 @@ public class SendTest extends TestCase {
     }
 
     public void testSetScheduleTimeDate(){
-        Date date = new Date(1380831494000L);
         format.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
-        send.setScheduleTime(format.format(date));
+        send.setScheduleTime(format.format(THURSDAY_OCT_3));
 
         String expected = "{\"schedule_time\":\"Thu Oct 03 20:18:14 UTC 2013\",\"options\":{}}";
         String result = gson.toJson(send);


### PR DESCRIPTION
Build only worked on a machine with the local timezone set to EDT. This should allow the build to work from any timezone.
