### PR TITLE
JsonResponse.isOK() should return true when error=false is reported in the response

### DIFF
--- a/src/main/com/sailthru/client/handler/response/JsonResponse.java
+++ b/src/main/com/sailthru/client/handler/response/JsonResponse.java
@@ -24,7 +24,7 @@ public class JsonResponse implements Response {
     }
 
     public boolean isOK() {
-        return (this.response != null) && !this.response.containsKey("error");
+        return (this.response != null) && (!this.response.containsKey("error") || this.response.get("error").equals("false"));
     }
 
     public Map<String, Object> getResponse() {


### PR DESCRIPTION
Currently seeing isOK() misreporting for getJobStatus() responses.
