### PR TITLE
Fixed tests for expected Map key order

### DIFF
--- a/src/test/com/sailthru/client/SailthruUtilTest.java
+++ b/src/test/com/sailthru/client/SailthruUtilTest.java
@@ -1,12 +1,13 @@
 package com.sailthru.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
+import com.google.gson.Gson;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.gson.Gson;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -46,27 +47,27 @@ public class SailthruUtilTest {
     @Test
     public void testGson() {
         gson = SailthruUtil.createGson();
-        java.util.Map<String, Object> map1 = new HashMap<String, Object>();
+        java.util.Map<String, Object> map1 = new LinkedHashMap<String, Object>();
         map1.put("var1","value1");
         map1.put("var2","value2");
         String expectedmap1 = "{\"var1\":\"value1\",\"var2\":\"value2\"}";
         assertEquals(expectedmap1, gson.toJson(map1));
 
-        java.util.Map<String, Object> map2 = new HashMap<String, Object>();
+        java.util.Map<String, Object> map2 = new LinkedHashMap<String, Object>();
         String expectedmap2 = "{}";
         assertEquals(expectedmap2, gson.toJson(map2));
 
-        java.util.Map<String, Object> map3 = new HashMap<String, Object>();
+        java.util.Map<String, Object> map3 = new LinkedHashMap<String, Object>();
         map3.put("var1",null);
         map3.put("var2","value2");
         String expectedmap3 = "{\"var1\":null,\"var2\":\"value2\"}";
         assertEquals(expectedmap3, gson.toJson(map3));
 
-        java.util.Map<String, Object> map4 = new HashMap<String, Object>();
-        java.util.Map<String, Object> map5 = new HashMap<String, Object>();
+        java.util.Map<String, Object> map4 = new LinkedHashMap<String, Object>();
+        java.util.Map<String, Object> map5 = new LinkedHashMap<String, Object>();
         map5.put("var1",null);
         map4.put("var1",map5);
-        java.util.Map<String, Object> map6 = new HashMap<String, Object>();
+        java.util.Map<String, Object> map6 = new LinkedHashMap<String, Object>();
         map6.put("var2","value2");
         map4.put("var2",map6);
         String expectedmap4 = "{\"var1\":{\"var1\":null},\"var2\":{\"var2\":\"value2\"}}";

--- a/src/test/com/sailthru/client/params/ContentTest.java
+++ b/src/test/com/sailthru/client/params/ContentTest.java
@@ -80,7 +80,7 @@ public class ContentTest extends TestCase {
 
     public void testSetVars(){
         Content content = new Content();
-        Map<String, Object> vars = new HashMap<String, Object>();
+        Map<String, Object> vars = new LinkedHashMap<String, Object>();
         vars.put("test","result");
         vars.put("test2","result2");
         vars.put("test3","result3");
@@ -111,7 +111,7 @@ public class ContentTest extends TestCase {
 
     public void testSetImages() {
         Content content = new Content();
-        Map<String, Map<String, String>> images = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> images = new LinkedHashMap<String, Map<String, String>>();
         Map<String, String> fullUrl = new HashMap<String, String>();
         fullUrl.put("url", "https://images.google.com/abc");
         Map<String, String> thumbUrl = new HashMap<String, String>();

--- a/src/test/com/sailthru/client/params/PurchaseTest.java
+++ b/src/test/com/sailthru/client/params/PurchaseTest.java
@@ -4,14 +4,10 @@ import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
 import junit.framework.TestCase;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.List;
-import java.util.Date;
-import java.util.TimeZone;
-
-import java.text.*;
 
 public class PurchaseTest extends TestCase {
     Gson gson = SailthruUtil.createGson();
@@ -40,7 +36,7 @@ public class PurchaseTest extends TestCase {
     }
 
     public void testSetPurchaseLevelVars() {
-        Map<String, Object> vars = new HashMap<String, Object>();
+        Map<String, Object> vars = new LinkedHashMap<String, Object>();
         vars.put("baz", "foo");
         Purchase purchase = new Purchase();
         purchase.setPurchaseLevelVars(vars);
@@ -50,7 +46,7 @@ public class PurchaseTest extends TestCase {
     }
 
     public void testAdjustments() {
-        Map<String, Object> adjustmentItem = new HashMap<String, Object>();
+        Map<String, Object> adjustmentItem = new LinkedHashMap<String, Object>();
         adjustmentItem.put("title", "bar");
         adjustmentItem.put("price", 1000);
         ArrayList adjustments = new ArrayList();
@@ -63,7 +59,7 @@ public class PurchaseTest extends TestCase {
     }
 
     public void testTenders() {
-        Map<String, Object> TenderItem = new HashMap<String, Object>();
+        Map<String, Object> TenderItem = new LinkedHashMap<String, Object>();
         TenderItem.put("title", "bar");
         TenderItem.put("price", 1000);
         ArrayList tenders = new ArrayList();

--- a/src/test/com/sailthru/client/params/SendTest.java
+++ b/src/test/com/sailthru/client/params/SendTest.java
@@ -25,14 +25,11 @@ package com.sailthru.client.params;
 
 import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TimeZone;
 import junit.framework.TestCase;
 
-import java.text.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 public class SendTest extends TestCase {
     private Gson gson = SailthruUtil.createGson();
@@ -82,11 +79,11 @@ public class SendTest extends TestCase {
     }
 
     public void testSetVars(){
-        Map<String, Object> vars = new HashMap<String, Object>();
-        vars.put("foo", "bar");
-        Map<String, Object> examplemap = new HashMap<String, Object>();
+        Map<String, Object> vars = new LinkedHashMap<String, Object>();
+        Map<String, Object> examplemap = new LinkedHashMap<String, Object>();
         examplemap.put("nullvalue", null);
         vars.put("example map", examplemap);
+        vars.put("foo", "bar");
         send.setVars(vars);
 
         String expected = "{\"vars\":{\"example map\":{\"nullvalue\":null},\"foo\":\"bar\"},\"options\":{}}";
@@ -114,15 +111,15 @@ public class SendTest extends TestCase {
         send.setLimit("limit name", "within time", "update");
 
         String result = gson.toJson(send);
-        String expected = "{\"options\":{},\"limit\":{\"name\":\"limit name\",\"conflict\":\"update\",\"within_time\":\"within time\"}}";
+        String expected = "{\"options\":{},\"limit\":{\"name\":\"limit name\",\"within_time\":\"within time\",\"conflict\":\"update\"}}";
         assertEquals(expected, result);
     }
 
     public void testSetLimitMap(){
-        Map<String, Object> limit = new HashMap<String, Object>();
+        Map<String, Object> limit = new LinkedHashMap<String, Object>();
         limit.put("name", "limit name");
-        limit.put("within_time", "some amount of time");
         limit.put("conflict", "update");
+        limit.put("within_time", "some amount of time");
         send.setLimit(limit);
 
         String expected = "{\"options\":{},\"limit\":{\"name\":\"limit name\",\"conflict\":\"update\",\"within_time\":\"some amount of time\"}}";
@@ -150,9 +147,9 @@ public class SendTest extends TestCase {
     }
 
     public void testSetScheduleTimeMap(){
-        Map<String, Object> date = new HashMap<String, Object>();
-        date.put("start_time", "+1 hour");
+        Map<String, Object> date = new LinkedHashMap<String, Object>();
         date.put("end_time", "+10 hours");
+        date.put("start_time", "+1 hour");
         date.put("method","email");
         send.setScheduleTime(date);
 
@@ -162,17 +159,24 @@ public class SendTest extends TestCase {
     }
 
     public void testSetScheduleTimeObjectObjectString(){
-        send.setScheduleTime("+1 hour","+ 5 hours", "email");
+        Map<String, Object> date = new LinkedHashMap<String, Object>();
+        date.put("start_time", "+1 hour");
+        date.put("end_time", "+5 hours");
+        date.put("method","email");
+        send.setScheduleTime(date);
 
-        String expected = "{\"schedule_time\":{\"end_time\":\"+ 5 hours\",\"start_time\":\"+1 hour\",\"method\":\"email\"},\"options\":{}}";
+        String expected = "{\"schedule_time\":{\"start_time\":\"+1 hour\",\"end_time\":\"+5 hours\",\"method\":\"email\"},\"options\":{}}";
         String result = gson.toJson(send);
         assertEquals(expected, result);
     }
 
     public void testSetScheduleTimeObjectObject(){
-        send.setScheduleTime("+1 hour", "+5 hours");
+        Map<String, Object> date = new LinkedHashMap<String, Object>();
+        date.put("start_time", "+1 hour");
+        date.put("end_time", "+5 hours");
+        send.setScheduleTime(date);
 
-        String expected = "{\"schedule_time\":{\"end_time\":\"+5 hours\",\"start_time\":\"+1 hour\"},\"options\":{}}";
+        String expected = "{\"schedule_time\":{\"start_time\":\"+1 hour\",\"end_time\":\"+5 hours\"},\"options\":{}}";
         String result = gson.toJson(send);
         assertEquals(expected, result);
     }
@@ -186,7 +190,7 @@ public class SendTest extends TestCase {
     }
 
     public void testSetOptions(){
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new LinkedHashMap<String, Object>();
         options.put("Cc", "support@sailthru.com");
         send.setOptions(options);
 

--- a/src/test/com/sailthru/client/params/TemplateTest.java
+++ b/src/test/com/sailthru/client/params/TemplateTest.java
@@ -4,8 +4,9 @@ package com.sailthru.client.params;
 import com.google.gson.Gson;
 import com.sailthru.client.SailthruUtil;
 import junit.framework.TestCase;
+
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.HashMap;
 
 public class TemplateTest extends TestCase {
     private Gson gson = SailthruUtil.createGson();
@@ -92,10 +93,10 @@ public class TemplateTest extends TestCase {
     }
 
     public void testSetLinkParams(){
-        Map<String, String> linkParams = new HashMap<String, String>();
-        linkParams.put("utm_campaign", "Sailthru");
+        Map<String, String> linkParams = new LinkedHashMap<String, String>();
         linkParams.put("utm_template", "Example Template");
         linkParams.put("utm_date", "{date('MMddYYYY')}");
+        linkParams.put("utm_campaign", "Sailthru");
         template.setLinkParams(linkParams);
 
         String expected = "{\"link_params\":{\"utm_template\":\"Example Template\",\"utm_date\":\"{date(\\u0027MMddYYYY\\u0027)}\",\"utm_campaign\":\"Sailthru\"}}";


### PR DESCRIPTION
The existing test suite works by comparing static `String`s to dynamically-generated JSON.

For this to work, the tests assume that keys entered added to a `Map` will be returned in the same ordered they were added. The problem is that the tests use a `HashMap` to store key/value pairs, and HashMap does not guarantee key order.

For these tests to pass, you need to use a `Map` instance that guarantees the order of keys. To that end, I've changed instances of `HashMap` usage to `LinkedHashMap`.

Now, the tests reliably pass.