### PR TITLE
Don't expose a dependency on slf4j-simple.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,25 +174,26 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.26</version>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.26</version>
+      <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <version>1.10.17</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>com.google.collections</groupId>
-          <artifactId>google-collections</artifactId>
-          <version>1.0</version>
-      </dependency>
+
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.17</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.google.collections</groupId>
+        <artifactId>google-collections</artifactId>
+        <version>1.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Also, use a current version of slf4j.

Context: it's not best practice for libraries to pick the particular implementation of slf4j to use.