### PR TITLE
Configurable connection pool settings

### DIFF
--- a/src/main/com/sailthru/client/AbstractSailthruClient.java
+++ b/src/main/com/sailthru/client/AbstractSailthruClient.java
@@ -32,7 +32,7 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 
 /**
- * Abstract class exposing genric API calls for Sailthru API as per http://docs.sailthru.com/api
+ * Abstract class exposing generic API calls for Sailthru API as per http://docs.sailthru.com/api
  * @author Prajwal Tuladhar <praj@sailthru.com>
  */
 public abstract class AbstractSailthruClient {
@@ -112,6 +112,8 @@ public abstract class AbstractSailthruClient {
         schemeRegistry.register(getScheme());
 
         ThreadSafeClientConnManager connManager = new ThreadSafeClientConnManager(schemeRegistry);
+        connManager.setMaxTotal(sailthruHttpClientConfiguration.getMaxTotalConnections());
+        connManager.setDefaultMaxPerRoute(sailthruHttpClientConfiguration.getDefaultMaxConnectionsPerRoute());
         return new SailthruHttpClient(connManager, params);
     }
 

--- a/src/main/com/sailthru/client/DefaultSailthruHttpClientConfiguration.java
+++ b/src/main/com/sailthru/client/DefaultSailthruHttpClientConfiguration.java
@@ -2,28 +2,45 @@ package com.sailthru.client;
 
 /**
  * Using this class will set connection and socket timeout to infinite timeout, which is certainly not recommended.
- * Default timeouts will be set as positive non-zero values (both for connection and socket) in next major relase only,
+ *
+ * Default timeouts will be set as positive non-zero values (both for connection and socket) in next major release only,
  * for maintaining compatibility with current minor release.
- * So, it's recommended to implement {@link SailthruHttpClientConfiguration} based on client requirements for now.
+ *
+ * Connection pool sizes match Apache HttpClient's defaults of 10 max and 2 max-per-route, though these may be too small
+ * for high throughput requests. Perceived high response time may be queueing within the connection pool. See
+ * https://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html#d5e393
+ *
+ * It's recommended to implement {@link SailthruHttpClientConfiguration} based on client requirements for now.
  */
 public class DefaultSailthruHttpClientConfiguration implements SailthruHttpClientConfiguration {
 
-    private static final int DEFAULT_CONN_TIMEOUT = 0;
-    private static final int DEFAULT_SO_CONN_TIMEOUT = 0;
-
+    @Override
     public int getConnectionTimeout() {
-        return DEFAULT_CONN_TIMEOUT;
+        return 0;
     }
 
+    @Override
     public int getSoTimeout() {
-        return DEFAULT_SO_CONN_TIMEOUT;
+        return 0;
     }
 
+    @Override
     public boolean getSoReuseaddr() {
         return false;
     }
 
+    @Override
     public boolean getTcpNoDelay() {
         return true;
+    }
+
+    @Override
+    public int getMaxTotalConnections() {
+        return 20;
+    }
+
+    @Override
+    public int getDefaultMaxConnectionsPerRoute() {
+        return 2;
     }
 }

--- a/src/main/com/sailthru/client/SailthruHttpClientConfiguration.java
+++ b/src/main/com/sailthru/client/SailthruHttpClientConfiguration.java
@@ -1,30 +1,40 @@
 package com.sailthru.client;
 
 /**
- * Interface for providing different options to customize HTTP specific flags
+ * Interface for customizing some HTTP client settings.
+ *
+ * {@link DefaultSailthruHttpClientConfiguration} provides default values but
+ * users may want to override those defaults by extending it or implementing
+ * this interface.
  */
 public interface SailthruHttpClientConfiguration {
     /**
-     * get connection timeout in milli seconds
-     * @return
+     * @return connection timeout in milliseconds
      */
     int getConnectionTimeout();
 
     /**
-     * get socket timeout in milli seconds
-     * @return
+     * @return socket timeout in milliseconds
      */
     int getSoTimeout();
 
     /**
-     * get socket reuse address boolean flag
-     * @return
+     * @return socket reuse address boolean flag
      */
     boolean getSoReuseaddr();
 
     /**
-     * get tcp no delay boolean flag
-     * @return
+     * @return TCP_NODELAY boolean setting
      */
     boolean getTcpNoDelay();
+
+    /**
+     * @return connection pool max total
+     */
+    int getMaxTotalConnections();
+
+    /**
+     * @return connection pool max per route
+     */
+    int getDefaultMaxConnectionsPerRoute();
 }

--- a/src/test/com/sailthru/client/SailthruHttpClientConfigurationTest.java
+++ b/src/test/com/sailthru/client/SailthruHttpClientConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.sailthru.client;
 
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.junit.Test;
@@ -17,6 +18,10 @@ public class SailthruHttpClientConfigurationTest {
         HttpParams params = client.httpClient.getParams();
         assertEquals("connection timeout", httpClientConfiguration.getConnectionTimeout(), HttpConnectionParams.getConnectionTimeout(params));
         assertEquals("socket timeout", httpClientConfiguration.getSoTimeout(), HttpConnectionParams.getSoTimeout(params));
+
+        ThreadSafeClientConnManager connManager = (ThreadSafeClientConnManager) client.httpClient.getConnectionManager();
+        assertEquals("max total connections", httpClientConfiguration.getMaxTotalConnections(), connManager.getMaxTotal());
+        assertEquals("default max connections per route", httpClientConfiguration.getDefaultMaxConnectionsPerRoute(), connManager.getDefaultMaxPerRoute());
     }
 
     private static class CustomSailthruHttpClientConfiguration implements SailthruHttpClientConfiguration {
@@ -35,6 +40,16 @@ public class SailthruHttpClientConfigurationTest {
 
         public boolean getTcpNoDelay() {
             return false;
+        }
+
+        @Override
+        public int getMaxTotalConnections() {
+            return 100;
+        }
+
+        @Override
+        public int getDefaultMaxConnectionsPerRoute() {
+            return 20;
         }
     }
 }


### PR DESCRIPTION
The default connection pool settings of 20 max total and 2 max per route
may be too constraining for high throughput applications which results
in queueing latency within the connection pool.

This still uses the conservative defaults but allows it to be increased
with a SailthruHttpClientConfiguration object.