### PR TITLE
Improve Purchase and PurchaseItem models with addition of user agent and images

### DIFF
--- a/src/main/com/sailthru/client/SailthruUtil.java
+++ b/src/main/com/sailthru/client/SailthruUtil.java
@@ -54,4 +54,23 @@ public class SailthruUtil {
                 .registerTypeHierarchyAdapter(Map.class, new NullSerializingMapTypeAdapter())
                 .create();
     }
+
+    /**
+     * Add a new image entry to the images map.
+     *
+     * @param images map containing the references of images. Can be null, in that case the returned map will be a new instance with the entry
+     * @param key key for the map, either "full" or "thumb"
+     * @param url url for the image to use
+     * @return a new map instance of the images parameter was null otherwise the updated map.
+     */
+    public static Map<String, Map<String, String>> putImage(Map<String, Map<String, String>> images, String key, String url) {
+        if (images == null) {
+            images = new HashMap<String, Map<String, String>>();
+        }
+        Map<String, String> urlMap = new HashMap<String, String>();
+        urlMap.put("url", url);
+        images.put(key, urlMap);
+        return images;
+    }
+
 }

--- a/src/main/com/sailthru/client/params/Content.java
+++ b/src/main/com/sailthru/client/params/Content.java
@@ -2,9 +2,10 @@ package com.sailthru.client.params;
 
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.ApiAction;
+import com.sailthru.client.SailthruUtil;
+
 import java.lang.reflect.Type;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
@@ -21,7 +22,7 @@ public class Content extends AbstractApiParams implements ApiParams {
     protected String title;
     protected String date;
     protected String expire_date;
-    protected List tags;
+    protected List<String> tags;
     protected Map<String, Object> vars;
     protected Map<String, Map<String, String>> images;
     protected List<Double> location;
@@ -112,22 +113,12 @@ public class Content extends AbstractApiParams implements ApiParams {
     }
 
     public Content setFullImage(String url) {
-        if (images == null) {
-            images = new HashMap<String, Map<String, String>>();
-        }
-        Map<String, String> urlMap = new HashMap<String, String>();
-        urlMap.put("url", url);
-        images.put("full", urlMap);
+        this.images = SailthruUtil.putImage(this.images, "full", url);
         return this;
     }
 
     public Content setThumbImage(String url) {
-        if (images == null) {
-            images = new HashMap<String, Map<String, String>>();
-        }
-        Map<String, String> urlMap = new HashMap<String, String>();
-        urlMap.put("url", url);
-        images.put("thumb", urlMap);
+        this.images = SailthruUtil.putImage(this.images, "thumb", url);
         return this;
     }
 

--- a/src/main/com/sailthru/client/params/Purchase.java
+++ b/src/main/com/sailthru/client/params/Purchase.java
@@ -48,6 +48,9 @@ public class Purchase extends AbstractApiParams implements ApiParams {
     @SerializedName("device_id")
     protected String deviceId;
 
+    @SerializedName("user_agent")
+    protected String userAgent;
+
     public Purchase setEmail(String email) {
         this.email = email;
         return this;
@@ -150,6 +153,15 @@ public class Purchase extends AbstractApiParams implements ApiParams {
 
     public Purchase setDeviceId(String deviceId) {
         this.deviceId = deviceId;
+        return this;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public Purchase setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
         return this;
     }
 

--- a/src/main/com/sailthru/client/params/PurchaseItem.java
+++ b/src/main/com/sailthru/client/params/PurchaseItem.java
@@ -17,8 +17,9 @@ public class PurchaseItem {
     protected String price;
     protected String id;
     protected String url;
-    protected List tags;
+    protected List<String> tags;
     protected Map<String, Object> vars;
+    protected Map<String, Map<String, String>> images;
 
     public PurchaseItem(Integer qty, String title, Integer price, String id, String url) {
         this.qty = qty.toString();
@@ -37,6 +38,34 @@ public class PurchaseItem {
         this.vars = vars;
         return this;
     }
+
+    public Map<String, Map<String, String>> getImages() {
+        return images;
+    }
+
+    /*
+     * A map of image names to { “url” : <url> } image maps.
+     * Use the name “full” to denote the full-sized image, and “thumb” to denote
+     * the thumbnail-sized image. Other image names are not reserved.
+     *
+     * @see #setFullImage(String)
+     * @see #setThumbImage(String)
+     */
+    public PurchaseItem setImages(Map<String, Map<String, String>> images) {
+        this.images = images;
+        return this;
+    }
+
+    public PurchaseItem setFullImage(String url) {
+        this.images = SailthruUtil.putImage(this.images, "full", url);
+        return this;
+    }
+
+    public PurchaseItem setThumbImage(String url) {
+        this.images = SailthruUtil.putImage(this.images, "thumb", url);
+        return this;
+    }
+
 
     public Map<String, Object> toHashMap() {
         Gson gson = SailthruUtil.createGson();

--- a/src/test/com/sailthru/client/SailthruUtilTest.java
+++ b/src/test/com/sailthru/client/SailthruUtilTest.java
@@ -77,12 +77,31 @@ public class SailthruUtilTest {
     @Test
     public void testGsonNull() {
         gson = SailthruUtil.createGson();
-        Map map = new HashMap();
+        Map<String, Object> map = new HashMap<String, Object>();
         map.put("baz", null);
         
         String expected = "{\"baz\":null}";
         String result = gson.toJson(map);
         
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void imagesMapIsUpdated() {
+        Map<String, Map<String, String>> map = SailthruUtil.putImage(null, "full", "https://something/full.jpg");
+        assertEquals(1, map.size());
+        assertEquals("https://something/full.jpg", map.get("full").get("url"));
+
+        map = SailthruUtil.putImage(map, "thumb", "https://something/thumb.jpg");
+        assertEquals(2, map.size());
+        assertEquals("https://something/thumb.jpg", map.get("thumb").get("url"));
+
+        map = SailthruUtil.putImage(map, "custom", "https://something/custom.jpg");
+        assertEquals(3, map.size());
+        assertEquals("https://something/custom.jpg", map.get("custom").get("url"));
+
+        map = SailthruUtil.putImage(map, "thumb", "https://something/anotherthumb.jpg");
+        assertEquals(3, map.size());
+        assertEquals("https://something/anotherthumb.jpg", map.get("thumb").get("url"));
     }
 }


### PR DESCRIPTION
This adds missing support of user agent in purchase as well as images in PurchaseItem
To avoid duplication, the logic to create a new image entry has been centralized in SailthruUtils
