### PR TITLE
Update external dependencies as well as internal one (plugins + test)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.9</version>
+      <version>4.13</version>
       <type>jar</type>
       <scope>test</scope>
       <optional>true</optional>
@@ -62,38 +62,38 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.4</version>
+      <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
+      <version>4.5.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.3</version>
+      <version>4.4.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.12</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.17</version>
+      <version>3.4.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>
@@ -125,7 +125,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -135,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -153,7 +153,7 @@
           <nohelp>true</nohelp>
           <doclint>none</doclint>
         </configuration>
-        <version>3.0.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -171,7 +171,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.0</version>
         <configuration>
           <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
           <show>public</show>

--- a/src/test/com/sailthru/client/AbstractSailthruClientTest.java
+++ b/src/test/com/sailthru/client/AbstractSailthruClientTest.java
@@ -1,7 +1,6 @@
 package com.sailthru.client;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.sailthru.client.http.SailthruHttpClient;
 import com.sailthru.client.params.Send;
 import org.apache.http.HttpHost;
@@ -18,7 +17,7 @@ import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,9 +25,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -59,7 +58,7 @@ public class AbstractSailthruClientTest {
         long resetTs = ((new Date().getTime() / 1000) * 1000) + 18000; // pretend the top of the next minute is 18 seconds from now
         Date resetDate = new Date(resetTs);
         CloseableHttpResponse httpResponse = getMockHttpResponseWithRateLimitHeaders(limit, remaining, resetDate);
-        doReturn(httpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), any(HttpContext.class));
+        doReturn(httpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
         sailthruClient.apiGet(ApiAction.send, ImmutableMap.<String,Object>of(Send.PARAM_SEND_ID, "some valid send id"));
 
@@ -95,7 +94,7 @@ public class AbstractSailthruClientTest {
         doReturn(sendHttpResponse).doReturn(listHttpResponse)
                                   .doReturn(returnHttpResponse)
                                   .when(httpClient)
-                                  .execute(any(HttpHost.class), any(HttpRequest.class), any(HttpContext.class));
+                                  .execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
         sailthruClient.apiGet(ApiAction.send, ImmutableMap.<String,Object>of(Send.PARAM_SEND_ID, "some valid send id"));
         sailthruClient.apiGet(ApiAction.list, ImmutableMap.<String,Object>of("list", "some list"));
@@ -133,7 +132,7 @@ public class AbstractSailthruClientTest {
         Date postResetDate = new Date(postResetTs);
         CloseableHttpResponse postHttpResponse = getMockHttpResponseWithRateLimitHeaders(postLimit, postRemaining, postResetDate);
 
-        doReturn(getHttpResponse).doReturn(postHttpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), any(HttpContext.class));
+        doReturn(getHttpResponse).doReturn(postHttpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
         sailthruClient.apiGet(ApiAction.list, ImmutableMap.<String,Object>of("list", "some list"));
         sailthruClient.apiPost(ApiAction.list, ImmutableMap.<String,Object>of("list", "some new list"));
@@ -152,10 +151,10 @@ public class AbstractSailthruClientTest {
     @Test
     public void testReturnUrl() throws IOException {
         CloseableHttpResponse response = getMockHttpResponseWithRateLimitHeaders(1, 1, new Date());
-        doReturn(response).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), any(HttpContext.class));
+        doReturn(response).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
         sailthruClient.apiPost(ApiAction.RETURN, Collections.<String, Object>emptyMap());
         verify(httpClient).executeHttpRequest(eq("https://api.sailthru.com/return"), eq(AbstractSailthruClient.HttpRequestMethod.POST),
-            any(Map.class), any(ResponseHandler.class), any(Map.class));
+            any(Map.class), any(ResponseHandler.class), (Map)any());
     }
 
     private CloseableHttpResponse getMockHttpResponseWithRateLimitHeaders(int limit, int remaining, Date reset) {


### PR DESCRIPTION
Update very old dependencies that are susceptible to cause conflict in today's environment and also have a ton of bugfixes. gson 2.2.4 was from 2013 for example.

    - Update gson to 2.8.6
    - Update httpclient to 4.5.12 and httpcore to 4.4.13
    - Update slf4j to 1.7.30
    - For internal use, update junit to 4.13, mockito to 3.4.6 and all maven plugins
    - Fix unit test to have correct mocking and remove deprecated usages

