### PR TITLE
Put slf4j-simple in the test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.30</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Having it the default scope propagates it to dependent projects, affecting their ability to choose a different slf4j binding.