### PR TITLE
Remove google-collections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
       <version>3.4.6</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.collections</groupId>
-      <artifactId>google-collections</artifactId>
-      <version>1.0</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/com/sailthru/client/AbstractSailthruClient.java
+++ b/src/main/com/sailthru/client/AbstractSailthruClient.java
@@ -1,6 +1,5 @@
 package com.sailthru.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.handler.JsonHandler;
@@ -336,11 +335,9 @@ public abstract class AbstractSailthruClient {
         customHeaders = headers;
     }
 
-    @VisibleForTesting
     void setSailthruHttpClient(SailthruHttpClient httpClient) {
         this.httpClient = httpClient;
     }
-
 
     private void recordRateLimitInfo(ApiAction action, HttpRequestMethod method, Object response) {
         Map<String,Object> responseMap = (Map<String,Object>) response;

--- a/src/test/com/sailthru/client/AbstractSailthruClientTest.java
+++ b/src/test/com/sailthru/client/AbstractSailthruClientTest.java
@@ -1,6 +1,5 @@
 package com.sailthru.client;
 
-import com.google.common.collect.ImmutableMap;
 import com.sailthru.client.http.SailthruHttpClient;
 import com.sailthru.client.params.Send;
 import org.apache.http.HttpHost;
@@ -23,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -60,7 +60,7 @@ public class AbstractSailthruClientTest {
         CloseableHttpResponse httpResponse = getMockHttpResponseWithRateLimitHeaders(limit, remaining, resetDate);
         doReturn(httpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
-        sailthruClient.apiGet(ApiAction.send, ImmutableMap.<String,Object>of(Send.PARAM_SEND_ID, "some valid send id"));
+        sailthruClient.apiGet(ApiAction.send, Collections.<String, Object>singletonMap(Send.PARAM_SEND_ID, "some valid send id"));
 
         LastRateLimitInfo rateLimitInfo = sailthruClient.getLastRateLimitInfo(ApiAction.send, AbstractSailthruClient.HttpRequestMethod.GET);
         assertEquals(limit, rateLimitInfo.getLimit());
@@ -96,9 +96,12 @@ public class AbstractSailthruClientTest {
                                   .when(httpClient)
                                   .execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
-        sailthruClient.apiGet(ApiAction.send, ImmutableMap.<String,Object>of(Send.PARAM_SEND_ID, "some valid send id"));
-        sailthruClient.apiGet(ApiAction.list, ImmutableMap.<String,Object>of("list", "some list"));
-        sailthruClient.apiPost(ApiAction.RETURN, ImmutableMap.of("email", "foo@bar.com", "items", Collections.emptyList()));
+        sailthruClient.apiGet(ApiAction.send, Collections.<String, Object>singletonMap(Send.PARAM_SEND_ID, "some valid send id"));
+        sailthruClient.apiGet(ApiAction.list, Collections.<String, Object>singletonMap("list", "some list"));
+        Map<String, Object> returnParams = new HashMap<String, Object>();
+        returnParams.put("email", "foo@bar.com");
+        returnParams.put("items", Collections.emptyList());
+        sailthruClient.apiPost(ApiAction.RETURN, returnParams);
 
         LastRateLimitInfo sendRateLimitInfo = sailthruClient.getLastRateLimitInfo(ApiAction.send, AbstractSailthruClient.HttpRequestMethod.GET);
         assertEquals(sendLimit, sendRateLimitInfo.getLimit());
@@ -134,8 +137,8 @@ public class AbstractSailthruClientTest {
 
         doReturn(getHttpResponse).doReturn(postHttpResponse).when(httpClient).execute(any(HttpHost.class), any(HttpRequest.class), (HttpContext)any());
 
-        sailthruClient.apiGet(ApiAction.list, ImmutableMap.<String,Object>of("list", "some list"));
-        sailthruClient.apiPost(ApiAction.list, ImmutableMap.<String,Object>of("list", "some new list"));
+        sailthruClient.apiGet(ApiAction.list, Collections.<String, Object>singletonMap("list", "some list"));
+        sailthruClient.apiPost(ApiAction.list, Collections.<String, Object>singletonMap("list", "some new list"));
 
         LastRateLimitInfo getLastRateLimitInfo = sailthruClient.getLastRateLimitInfo(ApiAction.list, AbstractSailthruClient.HttpRequestMethod.GET);
         assertEquals(getLimit, getLastRateLimitInfo.getLimit());


### PR DESCRIPTION
google-collections is old and has been succeeded by google-guava. It was only used in unit tests cases for the convenience of constructing small maps. These can be mostly replaced with Collections.singletonMap. Having it as a compile dependency meant that this was propagated to dependent projects.

Theoretically a dependent project could be relying on this transitive dependency and break when it is removed, so I think this should be a minor version bump.