### PR TITLE
[PT-525] Add content watch API to ApiAction enum

### DIFF
--- a/src/main/com/sailthru/client/ApiAction.java
+++ b/src/main/com/sailthru/client/ApiAction.java
@@ -23,5 +23,7 @@ public enum ApiAction {
     trigger,
     inbox,
     user,
-    RETURN // the case is inconsistent, but "return" is a reserved keyword
+    RETURN, // the case is inconsistent, but "return" is a reserved keyword
+    content_watch { public String toString() { return "content/watch"; } },
+    content_watch_profile { public String toString() { return "content/watch/profile"; } },
 }

--- a/src/test/com/sailthru/client/ApiActionTest.java
+++ b/src/test/com/sailthru/client/ApiActionTest.java
@@ -1,0 +1,16 @@
+package com.sailthru.client;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ApiActionTest {
+
+    @Test
+    public void testApiActionToString() {
+        ApiAction watchAction = ApiAction.content_watch;
+        ApiAction profileWatchAction = ApiAction.content_watch_profile;
+        assertEquals("content/watch", watchAction.toString());
+        assertEquals("content/watch/profile", profileWatchAction.toString());
+
+    }
+}


### PR DESCRIPTION
To support the new content watch API, actions need to be added to the ApiAction enum.

The unit test I acknowledge is pretty low value. I just wrote it to verify it does what I expect, and then figured i might as well include it. I'm happy to remove it if it's not wanted.