### PR TITLE
Add support to ImportJob for in-memory InputStream data

### DIFF
--- a/src/main/com/sailthru/client/AbstractSailthruClient.java
+++ b/src/main/com/sailthru/client/AbstractSailthruClient.java
@@ -8,6 +8,7 @@ import com.sailthru.client.handler.SailthruResponseHandler;
 import com.sailthru.client.handler.response.JsonResponse;
 import com.sailthru.client.http.SailthruHandler;
 import com.sailthru.client.http.SailthruHttpClient;
+import com.sailthru.client.params.ApiFileOrInputStreamParams;
 import com.sailthru.client.params.ApiFileParams;
 import com.sailthru.client.params.ApiParams;
 import java.io.IOException;
@@ -183,16 +184,16 @@ public abstract class AbstractSailthruClient {
      * Make HTTP Request to Sailthru API involving multi-part uploads but with Api Params rather than generalized Map, this is recommended way to make request if data structure is complex
      * @param method
      * @param apiParams
-     * @param fileParams
+     * @param fileOrInputStreamParams
      * @return Object
      * @throws IOException 
      */
-    protected Object httpRequest(HttpRequestMethod method, ApiParams apiParams, ApiFileParams fileParams) throws IOException {
+    protected Object httpRequest(HttpRequestMethod method, ApiParams apiParams, ApiFileOrInputStreamParams fileOrInputStreamParams) throws IOException {
         ApiAction action = apiParams.getApiCall();
         String url = apiUrl + "/" + action.toString().toLowerCase();
         String json = GSON.toJson(apiParams, apiParams.getType());
         Map<String, String> params = buildPayload(json);
-        Object response = httpClient.executeHttpRequest(url, method, params, fileParams.getFileParams(), handler, customHeaders);
+        Object response = httpClient.executeHttpRequest(url, method, params, fileOrInputStreamParams.getFileOrInputStreamParams(), handler, customHeaders);
         recordRateLimitInfo(action, method, response);
         return response;
     }
@@ -201,8 +202,8 @@ public abstract class AbstractSailthruClient {
         return new JsonResponse(httpRequest(method, apiParams));
     }
     
-    protected JsonResponse httpRequestJson(HttpRequestMethod method, ApiParams apiParams, ApiFileParams fileParams) throws IOException {
-        return new JsonResponse(httpRequest(method, apiParams, fileParams));
+    protected JsonResponse httpRequestJson(HttpRequestMethod method, ApiParams apiParams, ApiFileOrInputStreamParams fileOrInputStreamParams) throws IOException {
+        return new JsonResponse(httpRequest(method, apiParams, fileOrInputStreamParams));
     }
     
     protected JsonResponse httpRequestJson(ApiAction action, HttpRequestMethod method, Map<String, Object> data) throws IOException {
@@ -287,11 +288,11 @@ public abstract class AbstractSailthruClient {
     /**
      * HTTP POST Request with Interface implementation of ApiParams and ApiFileParams
      * @param data
-     * @param fileParams
+     * @param fileOrInputStreamParams
      * @throws IOException 
      */
-    public JsonResponse apiPost(ApiParams data, ApiFileParams fileParams) throws IOException {
-        return httpRequestJson(HttpRequestMethod.POST, data, fileParams);
+    public JsonResponse apiPost(ApiParams data, ApiFileOrInputStreamParams fileOrInputStreamParams) throws IOException {
+        return httpRequestJson(HttpRequestMethod.POST, data, fileOrInputStreamParams);
     }
     
 

--- a/src/main/com/sailthru/client/SailthruClient.java
+++ b/src/main/com/sailthru/client/SailthruClient.java
@@ -455,11 +455,11 @@ public class SailthruClient extends AbstractSailthruClient {
      * @throws IOException
      */
     public JsonResponse processUpdateJob(UpdateJob job) throws IOException {
-        return apiPost(job, job);
+        return apiPost(job, (ApiFileOrInputStreamParams) job);
     }
 
     public JsonResponse processPurchaseImportJob(PurchaseImportJob job) throws IOException {
-        return apiPost(job, job);
+        return apiPost(job, (ApiFileOrInputStreamParams) job);
     }
 
     public JsonResponse getUser(User user) throws IOException {

--- a/src/main/com/sailthru/client/http/FileOrInputStream.java
+++ b/src/main/com/sailthru/client/http/FileOrInputStream.java
@@ -1,0 +1,17 @@
+package com.sailthru.client.http;
+
+import java.io.File;
+import java.io.InputStream;
+
+public class FileOrInputStream {
+    public File file;
+    public InputStream inputStream;
+    public String inputStreamName = "noname.csv";
+
+    public boolean isAFile() {
+        return this.file != null;
+    }
+    public boolean isAnInputStream() {
+        return this.inputStream != null;
+    }
+}

--- a/src/main/com/sailthru/client/params/ApiFileOrInputStreamParams.java
+++ b/src/main/com/sailthru/client/params/ApiFileOrInputStreamParams.java
@@ -1,0 +1,11 @@
+package com.sailthru.client.params;
+
+import com.sailthru.client.http.FileOrInputStream;
+
+import java.io.File;
+import java.util.Map;
+
+
+public interface ApiFileOrInputStreamParams {
+    public Map<String, FileOrInputStream> getFileOrInputStreamParams();
+}

--- a/src/main/com/sailthru/client/params/job/ImportJob.java
+++ b/src/main/com/sailthru/client/params/job/ImportJob.java
@@ -2,8 +2,13 @@ package com.sailthru.client.params.job;
 
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.SailthruUtil;
+import com.sailthru.client.http.FileOrInputStream;
+import com.sailthru.client.params.ApiFileOrInputStreamParams;
 import com.sailthru.client.params.ApiFileParams;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.lang.reflect.Type;
@@ -13,12 +18,13 @@ import java.util.HashMap;
  *
  * @author Prajwal Tuladhar <praj@sailthru.com>
  */
-public class ImportJob extends Job implements ApiFileParams {
+public class ImportJob extends Job implements ApiFileOrInputStreamParams {
     
     private static final String JOB = "import";
     
     protected String emails;
-    protected transient File file = null;
+    protected transient FileOrInputStream fileOrInputStream = new FileOrInputStream();
+
     protected String list;
 
     public ImportJob() {
@@ -31,15 +37,20 @@ public class ImportJob extends Job implements ApiFileParams {
     }
     
     public ImportJob setFile(String filePath) {
-        this.file = new File(filePath);
+        this.fileOrInputStream.file = new File(filePath);
         return this;
     }
     
     public ImportJob setFile(File file) {
-        this.file = file;
+        this.fileOrInputStream.file = file;
         return this;
     }
-    
+
+    public ImportJob setInputStreamData(String data) {
+        this.fileOrInputStream.inputStream = new ByteArrayInputStream(data.getBytes());
+        return this;
+    }
+
     public ImportJob setList(String list) {
         this.list = list;
         return this;
@@ -50,12 +61,14 @@ public class ImportJob extends Job implements ApiFileParams {
         return new TypeToken<ImportJob>() {}.getType();
     }
     
-    
-    public Map<String, File> getFileParams() {
-        Map<String, File> files = new HashMap<String, File>();
-        if (this.file != null) {
-            files.put("file", this.file);
+    public Map<String, FileOrInputStream> getFileOrInputStreamParams() {
+        Map<String, FileOrInputStream> filesOrInputStreams = new HashMap<String, FileOrInputStream>();
+        if (this.fileOrInputStream.file != null) {
+            filesOrInputStreams.put("file", this.fileOrInputStream);
         }
-        return files;
+        if (this.fileOrInputStream.inputStream != null) {
+            filesOrInputStreams.put("file", this.fileOrInputStream);
+        }
+        return filesOrInputStreams;
     }
 }


### PR DESCRIPTION
# Overview

This pull requests adds functionality to the Sailthru Java Client for importing a list into Sailthru from an in-memory String. Without this new functionality, applications using the Client library first need to write the String to an external File in its local filesystem prior to upload, which is not always possible.

# Details

The current Sailthru Java Client `ImportJob` only accepts File objects or filenames (which it then internally converts to an `InputStream`). However in some secure compute environments, one cannot create Files and obtain paths to them.  It would be ideal if the Sailthru Java Client `ImportJob` class directly accepted an InputStream or data, but that functionality is not present.

We have therefore refactored `ImportJob` and associated code to accept data for its InputStream, without requiring a File to be passed in.  The result is that the following is now possible:

```java
SailthruClient sailthruClient = new SailthruClient(apiKey, apiSecret);
String list = "email,name\nperson.one@dmgt.com,Person One\nperson.two@dmgt.com,Person Two";
ImportJob importJob = new ImportJob()
                .setList("myTempMailingList")
                .setInputStreamData(list);
sailthruClient.processImportJob(importJob);
```

## Implementation

This pull request introduces a new class `FileOrInputStream` which can be either a `File` or an `InputStream`.  `SailthruHttpClient` is updated to inspect objects of this class to determine whether to forward the passed-in `File` or the `InputStream` (our new use case) to the MultipartEntityBuilder — which already accepts either a `File` or an `InputStream`.

cc @sindhute

