### PR TITLE
[CHA-541] adding setOptoutSmsStatus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.sailthru.client</groupId>
   <artifactId>sailthru-java-client</artifactId>
-  <version>2.2.1</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
     <url>http://github.com/sailthru/sailthru-java-client.git</url>
     <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-    <tag>sailthru-java-client-2.2.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.sailthru.client</groupId>
   <artifactId>sailthru-java-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.1</version>
   <packaging>jar</packaging>
 
   <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
     <url>http://github.com/sailthru/sailthru-java-client.git</url>
     <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>sailthru-java-client-2.2.1</tag>
   </scm>
 
   <distributionManagement>

--- a/src/main/com/sailthru/client/params/User.java
+++ b/src/main/com/sailthru/client/params/User.java
@@ -20,6 +20,7 @@ public class User extends AbstractApiParams implements ApiParams {
     protected Map<String, Object> vars;
     protected Map<String, Integer> lists;
     protected String optout_email;
+    protected String optout_sms_status;
     protected Map<String, Object> login;
     
     public User(String id) {
@@ -64,7 +65,12 @@ public class User extends AbstractApiParams implements ApiParams {
         this.optout_email = optoutEmail;
         return this;
     }
-    
+
+    public User setOptoutSmsStatus(String optoutSmsStatus) {
+        this.optout_sms_status = optoutSmsStatus;
+        return this;
+    }
+
     public User setLogin(Map<String, Object> login) {
         this.login = login;
         return this;

--- a/src/test/com/sailthru/client/params/UserTest.java
+++ b/src/test/com/sailthru/client/params/UserTest.java
@@ -110,6 +110,14 @@ public class UserTest extends TestCase {
         assertEquals(expected, result);
     }
 
+    public void testSetOptoutSmsStatus() {
+        user.setOptoutSmsStatus("opt-in");
+
+        String expected = "{\"optout_sms_status\":\"opt-in\"}";
+        String result = gson.toJson(user);
+        assertEquals(expected, result);
+    }
+
     public void testSetLogin() {
         Map<String, Object> login = new HashMap<String, Object>();
         login.put("ip", "123.456.789.0");


### PR DESCRIPTION
To set opt-out status in Sailthru from Segment inbound Identify requests, `sailthru-java-client` is required to support `set_sms_status`. 

Jira: https://sailthru.atlassian.net/browse/CHA-541