### PR TITLE
SRE-9014: Add support for in-memory InputStream data for Import jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
         <url>http://github.com/sailthru/sailthru-java-client.git</url>
         <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
         <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>sailthru-java-client-2.2.3</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <url>http://github.com/sailthru/sailthru-java-client.git</url>
         <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
         <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-        <tag>sailthru-java-client-2.2.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
         <url>http://github.com/sailthru/sailthru-java-client.git</url>
         <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
         <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>sailthru-java-client-2.3.0</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.4</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.4</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
         <url>http://github.com/sailthru/sailthru-java-client.git</url>
         <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
         <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-        <tag>sailthru-java-client-2.2.3</tag>
+        <tag>sailthru-java-client-2.2.4</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>
@@ -35,7 +35,7 @@
         <url>http://github.com/sailthru/sailthru-java-client.git</url>
         <connection>scm:git:git@github.com:sailthru/sailthru-java-client.git</connection>
         <developerConnection>scm:git:git@github.com:sailthru/sailthru-java-client.git</developerConnection>
-        <tag>sailthru-java-client-2.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/src/main/com/sailthru/client/AbstractSailthruClient.java
+++ b/src/main/com/sailthru/client/AbstractSailthruClient.java
@@ -192,7 +192,7 @@ public abstract class AbstractSailthruClient {
         String url = apiUrl + "/" + action.toString().toLowerCase();
         String json = GSON.toJson(apiParams, apiParams.getType());
         Map<String, String> params = buildPayload(json);
-        Object response = httpClient.executeHttpRequest(url, method, params, fileParams.getFileParams(), handler, customHeaders);
+        Object response = httpClient.executeHttpRequest2(url, method, params, fileParams.getFileParams(), handler, customHeaders);
         recordRateLimitInfo(action, method, response);
         return response;
     }

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -18,7 +18,7 @@ import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.HttpParams;
 
-import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -26,12 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-/**
- *
- * @author Prajwal Tuladhar <praj@sailthru.com>
- */
 public class SailthruHttpClient extends DefaultHttpClient {
-
     public SailthruHttpClient(ThreadSafeClientConnManager connManager,
 			HttpParams params) {
         super(connManager, params);
@@ -39,7 +34,7 @@ public class SailthruHttpClient extends DefaultHttpClient {
 
     private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams) throws UnsupportedEncodingException {
         List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>();
-        
+
         for (Entry<String, String> entry : queryParams.entrySet()) {
             nameValuePairs.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
@@ -58,10 +53,10 @@ public class SailthruHttpClient extends DefaultHttpClient {
         }
         return null;
     }
-    
-    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, File> files) throws UnsupportedEncodingException {
+
+    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, FileInputStream> files) throws UnsupportedEncodingException {
         List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>();
-        
+
         for( Entry<String, String> entry : queryParams.entrySet() ) {
             nameValuePairs.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
@@ -77,10 +72,10 @@ public class SailthruHttpClient extends DefaultHttpClient {
                 for (Entry<String, String> entry : queryParams.entrySet()) {
                     builder.addTextBody(entry.getKey(), entry.getValue());
                 }
-                for (Entry<String, File> fileEntry : files.entrySet()) {
+                for (Entry<String, FileInputStream> fileEntry : files.entrySet()) {
                     final String fileKey = fileEntry.getKey();
-                    final File file = fileEntry.getValue();
-                    final String filename = file.getName();
+                    final FileInputStream file = fileEntry.getValue();
+                    final String filename = "import_job_data.csv";
                     builder.addBinaryBody(fileKey, file, ContentType.APPLICATION_OCTET_STREAM, filename);
                 }
                 httpPost.setEntity(builder.build());
@@ -107,7 +102,7 @@ public class SailthruHttpClient extends DefaultHttpClient {
         return super.execute(request, responseHandler);
     }
     
-    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, File> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
+    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, FileInputStream> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
             throws IOException {
         HttpUriRequest request = this.buildRequest(urlString, method, params, fileParams);
         if (customHeaders != null && customHeaders.size() > 0) {

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -18,7 +18,10 @@ import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.HttpParams;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -55,7 +58,8 @@ public class SailthruHttpClient extends DefaultHttpClient {
         return null;
     }
 
-    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, InputStream> files) throws UnsupportedEncodingException {
+    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, Object> files)
+        throws UnsupportedEncodingException, FileNotFoundException {
         List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>();
 
         for( Entry<String, String> entry : queryParams.entrySet() ) {
@@ -73,11 +77,23 @@ public class SailthruHttpClient extends DefaultHttpClient {
                 for (Entry<String, String> entry : queryParams.entrySet()) {
                     builder.addTextBody(entry.getKey(), entry.getValue());
                 }
-                for (Entry<String, InputStream> fileEntry : files.entrySet()) {
-                    final String fileKey = fileEntry.getKey();
-                    final InputStream file = fileEntry.getValue();
-                    final String filename = "import_job_data.csv";
-                    builder.addBinaryBody(fileKey, file, ContentType.APPLICATION_OCTET_STREAM, filename);
+
+                for (Entry<String, Object> fileObjectEntry : files.entrySet()) {
+                    File file;
+                    InputStream inputStream;
+                    String fileKey = fileObjectEntry.getKey();
+                    String filename;
+
+                    try {
+                        file = (File) fileObjectEntry.getValue();
+                        filename = file.getName();
+                        inputStream = new FileInputStream(file);
+                    } catch (ClassCastException e) {
+                        filename = "import_job_data_" + fileKey + ".csv";
+                        inputStream = (ByteArrayInputStream) fileObjectEntry.getValue();
+                    }
+
+                    builder.addBinaryBody(fileKey, inputStream, ContentType.APPLICATION_OCTET_STREAM, filename);
                 }
                 httpPost.setEntity(builder.build());
 
@@ -102,8 +118,8 @@ public class SailthruHttpClient extends DefaultHttpClient {
         
         return super.execute(request, responseHandler);
     }
-    
-    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, InputStream> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
+
+    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, Object> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
             throws IOException {
         HttpUriRequest request = this.buildRequest(urlString, method, params, fileParams);
         if (customHeaders != null && customHeaders.size() > 0) {

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -115,26 +115,26 @@ public class SailthruHttpClient extends DefaultHttpClient {
                 for (Entry<String, Object> fileObjectEntry : files.entrySet()) {
                     File file;
                     InputStream inputStream;
-                    String fileKey = fileObjectEntry.getKey();
-                    Object fileValue = fileObjectEntry.getValue();
+                    String fileObjKey = fileObjectEntry.getKey();
+                    Object fileObjValue = fileObjectEntry.getValue();
                     String filename;
 
                     // Object should either be File or InputStream
-                    if (fileValue instanceof File) {
-                      file = (File) fileValue;
+                    if (fileObjValue instanceof File) {
+                      file = (File) fileObjValue;
                       filename = file.getName();
                       inputStream = new FileInputStream(file);
-                    } else if (fileValue instanceof InputStream) {
-                      filename = "import_job_data_" + fileKey + ".csv";
-                      inputStream = (InputStream) fileObjectEntry.getValue();
+                    } else if (fileObjValue instanceof InputStream) {
+                      filename = "import_job_data_" + fileObjKey + ".csv";
+                      inputStream = (InputStream) fileObjValue;
                     } else {
                       throw new IllegalArgumentException("File param value should be of File or an InputStream type");
                     }
 
-                    builder.addBinaryBody(fileKey, inputStream, ContentType.APPLICATION_OCTET_STREAM, filename);
+                    builder.addBinaryBody(fileObjKey, inputStream, ContentType.APPLICATION_OCTET_STREAM, filename);
                 }
-                httpPost.setEntity(builder.build());
 
+                httpPost.setEntity(builder.build());
                 return httpPost;
 
             case DELETE:

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -58,38 +59,10 @@ public class SailthruHttpClient extends DefaultHttpClient {
         return null;
     }
 
-    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, File> files) {
-        List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>();
-
-        for( Entry<String, String> entry : queryParams.entrySet() ) {
-            nameValuePairs.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
-        }
-
-        switch(method) {
-        case GET:
-            return new HttpGet(urlString + "?" + extractQueryString(nameValuePairs));
-
-        case POST:
-            HttpPost httpPost = new HttpPost(urlString);
-            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-            builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
-            for (Entry<String, String> entry : queryParams.entrySet()) {
-                builder.addTextBody(entry.getKey(), entry.getValue());
-            }
-            for (Entry<String, File> fileEntry : files.entrySet()) {
-                final String fileKey = fileEntry.getKey();
-                final File file = fileEntry.getValue();
-                final String filename = file.getName();
-                builder.addBinaryBody(fileKey, file, ContentType.APPLICATION_OCTET_STREAM, filename);
-            }
-            httpPost.setEntity(builder.build());
-
-            return httpPost;
-
-        case DELETE:
-            return new HttpDelete(urlString + "?" + extractQueryString(nameValuePairs));
-        }
-        return null;
+    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, File> files)
+      throws FileNotFoundException {
+      Map<String, Object> fileObj = new HashMap<String, Object>(files);
+      return buildRequest2(urlString, method, queryParams, fileObj);
     }
 
     private HttpUriRequest buildRequest2(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, Object> files)

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -20,6 +20,7 @@ import org.apache.http.params.HttpParams;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ public class SailthruHttpClient extends DefaultHttpClient {
         return null;
     }
 
-    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, FileInputStream> files) throws UnsupportedEncodingException {
+    private HttpUriRequest buildRequest(String urlString, HttpRequestMethod method, Map<String, String> queryParams, Map<String, InputStream> files) throws UnsupportedEncodingException {
         List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>();
 
         for( Entry<String, String> entry : queryParams.entrySet() ) {
@@ -72,9 +73,9 @@ public class SailthruHttpClient extends DefaultHttpClient {
                 for (Entry<String, String> entry : queryParams.entrySet()) {
                     builder.addTextBody(entry.getKey(), entry.getValue());
                 }
-                for (Entry<String, FileInputStream> fileEntry : files.entrySet()) {
+                for (Entry<String, InputStream> fileEntry : files.entrySet()) {
                     final String fileKey = fileEntry.getKey();
-                    final FileInputStream file = fileEntry.getValue();
+                    final InputStream file = fileEntry.getValue();
                     final String filename = "import_job_data.csv";
                     builder.addBinaryBody(fileKey, file, ContentType.APPLICATION_OCTET_STREAM, filename);
                 }
@@ -102,7 +103,7 @@ public class SailthruHttpClient extends DefaultHttpClient {
         return super.execute(request, responseHandler);
     }
     
-    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, FileInputStream> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
+    public Object executeHttpRequest(String urlString, HttpRequestMethod method, Map<String, String> params, Map<String, InputStream> fileParams, ResponseHandler<Object> responseHandler, Map<String, String> customHeaders)
             throws IOException {
         HttpUriRequest request = this.buildRequest(urlString, method, params, fileParams);
         if (customHeaders != null && customHeaders.size() > 0) {

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -84,6 +84,8 @@ public class SailthruHttpClient extends DefaultHttpClient {
                     String fileKey = fileObjectEntry.getKey();
                     String filename;
 
+                    // Object could either be File or ByteArrayInputStream
+                    // We type cast and see which one it is:
                     try {
                         file = (File) fileObjectEntry.getValue();
                         filename = file.getName();

--- a/src/main/com/sailthru/client/http/SailthruHttpClient.java
+++ b/src/main/com/sailthru/client/http/SailthruHttpClient.java
@@ -116,17 +116,19 @@ public class SailthruHttpClient extends DefaultHttpClient {
                     File file;
                     InputStream inputStream;
                     String fileKey = fileObjectEntry.getKey();
+                    Object fileValue = fileObjectEntry.getValue();
                     String filename;
 
-                    // Object could either be File or ByteArrayInputStream
-                    // We type cast and see which one it is:
-                    try {
-                        file = (File) fileObjectEntry.getValue();
-                        filename = file.getName();
-                        inputStream = new FileInputStream(file);
-                    } catch (ClassCastException e) {
-                        filename = "import_job_data_" + fileKey + ".csv";
-                        inputStream = (ByteArrayInputStream) fileObjectEntry.getValue();
+                    // Object should either be File or InputStream
+                    if (fileValue instanceof File) {
+                      file = (File) fileValue;
+                      filename = file.getName();
+                      inputStream = new FileInputStream(file);
+                    } else if (fileValue instanceof InputStream) {
+                      filename = "import_job_data_" + fileKey + ".csv";
+                      inputStream = (InputStream) fileObjectEntry.getValue();
+                    } else {
+                      throw new IllegalArgumentException("File param value should be of File or an InputStream type");
                     }
 
                     builder.addBinaryBody(fileKey, inputStream, ContentType.APPLICATION_OCTET_STREAM, filename);

--- a/src/main/com/sailthru/client/params/ApiFileParams.java
+++ b/src/main/com/sailthru/client/params/ApiFileParams.java
@@ -1,12 +1,11 @@
 package com.sailthru.client.params;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.Map;
 
-/**
- *
-* @author Prajwal Tuladhar <praj@sailthru.com>
- */
 public interface ApiFileParams {
-    public Map<String, File> getFileParams();
+    public Map<String, FileInputStream> getFileParams();
 }

--- a/src/main/com/sailthru/client/params/ApiFileParams.java
+++ b/src/main/com/sailthru/client/params/ApiFileParams.java
@@ -7,5 +7,5 @@ import java.io.InputStream;
 import java.util.Map;
 
 public interface ApiFileParams {
-    public Map<String, FileInputStream> getFileParams();
+    public Map<String, InputStream> getFileParams();
 }

--- a/src/main/com/sailthru/client/params/ApiFileParams.java
+++ b/src/main/com/sailthru/client/params/ApiFileParams.java
@@ -1,11 +1,7 @@
 package com.sailthru.client.params;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.util.Map;
 
 public interface ApiFileParams {
-    public Map<String, InputStream> getFileParams();
+    Map<String, Object> getFileParams();
 }

--- a/src/main/com/sailthru/client/params/job/ImportJob.java
+++ b/src/main/com/sailthru/client/params/job/ImportJob.java
@@ -6,9 +6,11 @@ import com.sailthru.client.params.ApiFileParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.lang.reflect.Type;
@@ -18,7 +20,7 @@ public class ImportJob extends Job implements ApiFileParams {
     private static final String JOB = "import";
     protected static Logger logger = LoggerFactory.getLogger(ImportJob.class);
     protected String emails;
-    protected transient FileInputStream file = null;
+    protected transient InputStream file = null;
     protected String list;
 
     public ImportJob() {
@@ -49,11 +51,7 @@ public class ImportJob extends Job implements ApiFileParams {
     }
 
     public ImportJob setFileInputStream(String data) {
-        try {
-            this.file = new FileInputStream(data);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = new ByteArrayInputStream(data.getBytes());
         return this;
     }
     
@@ -67,8 +65,8 @@ public class ImportJob extends Job implements ApiFileParams {
         return new TypeToken<ImportJob>() {}.getType();
     }
 
-    public Map<String, FileInputStream> getFileParams() {
-        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
+    public Map<String, InputStream> getFileParams() {
+        Map<String, InputStream> files = new HashMap<String, InputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/ImportJob.java
+++ b/src/main/com/sailthru/client/params/job/ImportJob.java
@@ -38,7 +38,7 @@ public class ImportJob extends Job implements ApiFileParams {
         return this;
     }
 
-    public ImportJob setFileInputStream(String data) {
+    public ImportJob setFileDataAsString(String data) {
         this.fileInputStream = new ByteArrayInputStream(data.getBytes());
         return this;
     }

--- a/src/main/com/sailthru/client/params/job/ImportJob.java
+++ b/src/main/com/sailthru/client/params/job/ImportJob.java
@@ -3,22 +3,22 @@ package com.sailthru.client.params.job;
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.SailthruUtil;
 import com.sailthru.client.params.ApiFileParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 
-/**
- *
- * @author Prajwal Tuladhar <praj@sailthru.com>
- */
 public class ImportJob extends Job implements ApiFileParams {
-    
     private static final String JOB = "import";
-    
+    protected static Logger logger = LoggerFactory.getLogger(ImportJob.class);
     protected String emails;
-    protected transient File file = null;
+    protected transient FileInputStream file = null;
     protected String list;
 
     public ImportJob() {
@@ -29,14 +29,31 @@ public class ImportJob extends Job implements ApiFileParams {
         this.emails = SailthruUtil.arrayListToCSV(emails);
         return this;
     }
-    
+
     public ImportJob setFile(String filePath) {
-        this.file = new File(filePath);
+        try {
+            this.file = new FileInputStream(filePath);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
-    
+
     public ImportJob setFile(File file) {
-        this.file = file;
+        try {
+            this.file = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
+        return this;
+    }
+
+    public ImportJob setFileInputStream(String data) {
+        try {
+            this.file = new FileInputStream(data);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
     
@@ -49,10 +66,9 @@ public class ImportJob extends Job implements ApiFileParams {
     public Type getType() {
         return new TypeToken<ImportJob>() {}.getType();
     }
-    
-    
-    public Map<String, File> getFileParams() {
-        Map<String, File> files = new HashMap<String, File>();
+
+    public Map<String, FileInputStream> getFileParams() {
+        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/ImportJob.java
+++ b/src/main/com/sailthru/client/params/job/ImportJob.java
@@ -3,13 +3,9 @@ package com.sailthru.client.params.job;
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.SailthruUtil;
 import com.sailthru.client.params.ApiFileParams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -18,9 +14,9 @@ import java.util.HashMap;
 
 public class ImportJob extends Job implements ApiFileParams {
     private static final String JOB = "import";
-    protected static Logger logger = LoggerFactory.getLogger(ImportJob.class);
     protected String emails;
-    protected transient InputStream file = null;
+    protected transient File file = null;
+    protected transient InputStream fileInputStream = null;
     protected String list;
 
     public ImportJob() {
@@ -33,25 +29,17 @@ public class ImportJob extends Job implements ApiFileParams {
     }
 
     public ImportJob setFile(String filePath) {
-        try {
-            this.file = new FileInputStream(filePath);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = new File(filePath);
         return this;
     }
 
     public ImportJob setFile(File file) {
-        try {
-            this.file = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = file;
         return this;
     }
 
     public ImportJob setFileInputStream(String data) {
-        this.file = new ByteArrayInputStream(data.getBytes());
+        this.fileInputStream = new ByteArrayInputStream(data.getBytes());
         return this;
     }
     
@@ -65,10 +53,12 @@ public class ImportJob extends Job implements ApiFileParams {
         return new TypeToken<ImportJob>() {}.getType();
     }
 
-    public Map<String, InputStream> getFileParams() {
-        Map<String, InputStream> files = new HashMap<String, InputStream>();
+    public Map<String, Object> getFileParams() {
+        Map<String, Object> files = new HashMap<String, Object>();
         if (this.file != null) {
             files.put("file", this.file);
+        } else if (this.fileInputStream != null) {
+            files.put("file", this.fileInputStream);
         }
         return files;
     }

--- a/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
+++ b/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
@@ -2,27 +2,39 @@ package com.sailthru.client.params.job;
 
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.params.ApiFileParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PurchaseImportJob extends Job implements ApiFileParams {
-
-    protected transient File file = null;
+    protected static Logger logger = LoggerFactory.getLogger(PurchaseImportJob.class);
+    protected transient FileInputStream file = null;
 
     public PurchaseImportJob() {
         this.job = "purchase_import";
     }
 
     public PurchaseImportJob setFile(String filePath) {
-        this.file = new File(filePath);
+        try {
+            this.file = new FileInputStream(filePath);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
 
     public PurchaseImportJob setFile(File file) {
-        this.file = file;
+        try {
+            this.file = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
 
@@ -31,8 +43,8 @@ public class PurchaseImportJob extends Job implements ApiFileParams {
         return new TypeToken<PurchaseImportJob>() {}.getType();
     }
 
-    public Map<String, File> getFileParams() {
-        Map<String, File> files = new HashMap<String, File>();
+    public Map<String, FileInputStream> getFileParams() {
+        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
+++ b/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
@@ -8,13 +8,14 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PurchaseImportJob extends Job implements ApiFileParams {
     protected static Logger logger = LoggerFactory.getLogger(PurchaseImportJob.class);
-    protected transient FileInputStream file = null;
+    protected transient InputStream file = null;
 
     public PurchaseImportJob() {
         this.job = "purchase_import";
@@ -43,8 +44,8 @@ public class PurchaseImportJob extends Job implements ApiFileParams {
         return new TypeToken<PurchaseImportJob>() {}.getType();
     }
 
-    public Map<String, FileInputStream> getFileParams() {
-        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
+    public Map<String, InputStream> getFileParams() {
+        Map<String, InputStream> files = new HashMap<String, InputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
+++ b/src/main/com/sailthru/client/params/job/PurchaseImportJob.java
@@ -2,40 +2,26 @@ package com.sailthru.client.params.job;
 
 import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.params.ApiFileParams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PurchaseImportJob extends Job implements ApiFileParams {
-    protected static Logger logger = LoggerFactory.getLogger(PurchaseImportJob.class);
-    protected transient InputStream file = null;
+    protected transient File file = null;
 
     public PurchaseImportJob() {
         this.job = "purchase_import";
     }
 
     public PurchaseImportJob setFile(String filePath) {
-        try {
-            this.file = new FileInputStream(filePath);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = new File(filePath);
         return this;
     }
 
     public PurchaseImportJob setFile(File file) {
-        try {
-            this.file = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = file;
         return this;
     }
 
@@ -44,8 +30,8 @@ public class PurchaseImportJob extends Job implements ApiFileParams {
         return new TypeToken<PurchaseImportJob>() {}.getType();
     }
 
-    public Map<String, InputStream> getFileParams() {
-        Map<String, InputStream> files = new HashMap<String, InputStream>();
+    public Map<String, Object> getFileParams() {
+        Map<String, Object> files = new HashMap<String, Object>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/UpdateJob.java
+++ b/src/main/com/sailthru/client/params/job/UpdateJob.java
@@ -5,13 +5,8 @@ import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.SailthruUtil;
 import com.sailthru.client.params.ApiFileParams;
 import com.sailthru.client.params.query.Query;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.HashMap;
@@ -19,12 +14,11 @@ import java.util.List;
 import java.util.Map;
 
 public class UpdateJob extends Job implements ApiFileParams {
-    protected static Logger logger = LoggerFactory.getLogger(UpdateJob.class);
     private static final String JOB = "update";
 
     protected String emails;
     protected String url;
-    protected transient InputStream file;
+    protected transient File file;
     protected Map<String, Object> update;
     protected Map<String, Object> query;
 
@@ -49,20 +43,12 @@ public class UpdateJob extends Job implements ApiFileParams {
     }
     
     public UpdateJob setFile(File file) {
-        try {
-            this.file = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = file;
         return this;
     }
     
     public UpdateJob setFile(String file) {
-        try {
-            this.file = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            logger.error(e.getMessage());
-        }
+        this.file = new File(file);
         return this;
     }
     
@@ -96,8 +82,8 @@ public class UpdateJob extends Job implements ApiFileParams {
         return new TypeToken<UpdateJob>() {}.getType();
     }
 
-    public Map<String, InputStream> getFileParams() {
-        Map<String, InputStream> files = new HashMap<String, InputStream>();
+    public Map<String, Object> getFileParams() {
+        Map<String, Object> files = new HashMap<String, Object>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/UpdateJob.java
+++ b/src/main/com/sailthru/client/params/job/UpdateJob.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.HashMap;
@@ -23,7 +24,7 @@ public class UpdateJob extends Job implements ApiFileParams {
 
     protected String emails;
     protected String url;
-    protected transient FileInputStream file;
+    protected transient InputStream file;
     protected Map<String, Object> update;
     protected Map<String, Object> query;
 
@@ -95,8 +96,8 @@ public class UpdateJob extends Job implements ApiFileParams {
         return new TypeToken<UpdateJob>() {}.getType();
     }
 
-    public Map<String, FileInputStream> getFileParams() {
-        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
+    public Map<String, InputStream> getFileParams() {
+        Map<String, InputStream> files = new HashMap<String, InputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }

--- a/src/main/com/sailthru/client/params/job/UpdateJob.java
+++ b/src/main/com/sailthru/client/params/job/UpdateJob.java
@@ -5,28 +5,28 @@ import com.google.gson.reflect.TypeToken;
 import com.sailthru.client.SailthruUtil;
 import com.sailthru.client.params.ApiFileParams;
 import com.sailthru.client.params.query.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- *
- * @author Prajwal Tuladhar <praj@sailthru.com>
- */
 public class UpdateJob extends Job implements ApiFileParams {
-    
+    protected static Logger logger = LoggerFactory.getLogger(UpdateJob.class);
     private static final String JOB = "update";
-    
+
     protected String emails;
     protected String url;
-    protected transient File file;
+    protected transient FileInputStream file;
     protected Map<String, Object> update;
     protected Map<String, Object> query;
-    
+
     public UpdateJob() {
         this.job = JOB;
         this.update = new HashMap<String, Object>();
@@ -48,12 +48,20 @@ public class UpdateJob extends Job implements ApiFileParams {
     }
     
     public UpdateJob setFile(File file) {
-        this.file = file;
+        try {
+            this.file = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
     
     public UpdateJob setFile(String file) {
-        this.file = new File(file);
+        try {
+            this.file = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            logger.error(e.getMessage());
+        }
         return this;
     }
     
@@ -87,8 +95,8 @@ public class UpdateJob extends Job implements ApiFileParams {
         return new TypeToken<UpdateJob>() {}.getType();
     }
 
-    public Map<String, File> getFileParams() {
-        Map<String, File> files = new HashMap<String, File>();
+    public Map<String, FileInputStream> getFileParams() {
+        Map<String, FileInputStream> files = new HashMap<String, FileInputStream>();
         if (this.file != null) {
             files.put("file", this.file);
         }


### PR DESCRIPTION
## Description
Some clients like DMGT would prefer to import a list (via import job) into our system by using an in-memory string, in addition to the currently supported `file` (in local filesystem) or `url` (remote file url) options, due to security constraints on their end:

"[I]n some secure compute environments, one cannot create Files and obtain paths to them"

### Changes
The client can now provide a string like the following:
```"email,name\nperson.one@dmgt.com,Person One\nperson.two@dmgt.com,Person Two"```

The client would start by calling the new setter method with such a string which 
```java
    public ImportJob setFileDataAsString(String data) {
        this.file = new ByteArrayInputStream(data.getBytes());
        return this;
    }
```

To accommodate `InputStream` while maintaining backwards compatibility, public method `executeHttpRequest` had a change in signature: `fileParams` is now a map of String to Object:
```Map<String, Object> fileParams```

These changes necessitated a change to the `ApiFileParams` interface and consequently the `Update` and `PurchaseImport` job implementations (non-breaking).

### Testing
Currently doing manual testing with a newly generated JAR. Results to be updated soon.