### PR TITLE
PLA-10186: Add link_params support to Blast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sailthru.client</groupId>
     <artifactId>sailthru-java-client</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sailthru-java-client</name>

--- a/src/main/com/sailthru/client/params/Blast.java
+++ b/src/main/com/sailthru/client/params/Blast.java
@@ -40,6 +40,7 @@ public class Blast extends AbstractApiParams implements ApiParams {
     protected String data_feed_url;
     protected String setup;
     protected Map<String, Object> vars;
+    protected Map<String, String> link_params;
 
     public Blast(String name, String list, String scheduleTime, String fromName, String fromEmail, String subject, String contentHtml, String contentText) {
         this.name = name;
@@ -134,6 +135,11 @@ public class Blast extends AbstractApiParams implements ApiParams {
 
     public Blast enableLinkTracking() {
         this.is_link_tracking = 1;
+        return this;
+    }
+
+    public Blast setLinkParams(Map<String, String> linkParams) {
+        this.link_params = linkParams;
         return this;
     }
 


### PR DESCRIPTION
Add support for `link_params` on the Blast API endpoint.