### PR TITLE
Upgrade to gson 2.13.2 to fix "Cannot override built-in adapter for class java.lang.Object"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.13.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -127,8 +127,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/com/sailthru/client/handler/JsonHandler.java
+++ b/src/main/com/sailthru/client/handler/JsonHandler.java
@@ -17,88 +17,22 @@ import java.util.Map;
 
 /**
  * handles JSON response from server
- *
- * @author Prajwal Tuladhar <praj@sailthru.com>
  */
 public class JsonHandler implements SailthruResponseHandler {
 
     public static final String format = "json";
 
-    
+    @Override
     public Object parseResponse(String response) {
         GsonBuilder builder = new GsonBuilder();
         builder.setDateFormat(SailthruUtil.SAILTHRU_API_DATE_FORMAT);
-        builder.registerTypeAdapter(Object.class, new NaturalDeserializer());
         Gson gson = builder.create();
-        return gson.fromJson(response, Object.class);
+        return gson.fromJson(response, Map.class);
     }
 
-    
+    @Override
     public String getFormat() {
         return format;
     }
 
-    // http://stackoverflow.com/questions/2779251/convert-json-to-hashmap-using-gson-in-java/4799594#4799594
-    //Will get rid of this at some point
-    class NaturalDeserializer implements JsonDeserializer<Object>  {
-
-        public Object deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-            if (json.isJsonNull()) {
-                return null;
-            }
-            else if (json.isJsonPrimitive()) {
-                return handlePrimitive(json.getAsJsonPrimitive());
-            }
-            else if (json.isJsonArray()) {
-                return handleArray(json.getAsJsonArray(), context);
-            }
-            else {
-                return handleObject(json.getAsJsonObject(), context);
-            }
-        }
-
-        private Object handlePrimitive(JsonPrimitive json) {
-            if (json.isString()) {
-                return json.getAsString();
-            }
-            else if (json.isBoolean()) {
-                return json.getAsBoolean();
-            }
-            else {
-                BigDecimal bigDec = json.getAsBigDecimal();
-                // Find out if it is an int type
-                try {
-                    bigDec.toBigIntegerExact();
-                    try {
-                        return bigDec.intValueExact();
-                    }
-                    catch (ArithmeticException e) {}
-                    return bigDec.longValue();
-                }
-                catch (ArithmeticException e) {}
-                return bigDec.doubleValue();
-            }
-        }
-
-        private Object handleArray(JsonArray json, JsonDeserializationContext context) {            
-            Object[] array = new Object[json.size()];
-            for (int i = 0; i < array.length; i++) {
-                if (json.get(i).isJsonObject()) {
-                    array[i] = handleObject((JsonObject)json.get(i), context);
-                }
-                else {
-                    array[i] = context.deserialize(json.get(i), Object.class);
-                }                                
-            }
-            return array;
-        }
-
-        private Object handleObject(JsonObject json, JsonDeserializationContext context) {
-            Map<String, Object> map = new HashMap<String, Object>();
-            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {                
-                map.put(entry.getKey(), context.deserialize(entry.getValue(), Object.class));
-            }
-            return map;
-        }
-    }
 }

--- a/src/test/com/sailthru/client/handler/JsonHandlerTest.java
+++ b/src/test/com/sailthru/client/handler/JsonHandlerTest.java
@@ -1,0 +1,246 @@
+package com.sailthru.client.handler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link JsonHandler} class.
+ * Tests the parseResponse method to ensure it correctly parses JSON payloads
+ * and returns a Map of objects with the appropriate structure and data types.
+ */
+public class JsonHandlerTest {
+
+    private JsonHandler jsonHandler;
+
+    @Before
+    public void setUp() {
+        jsonHandler = new JsonHandler();
+    }
+
+    @Test
+    public void testParseResponseWithContent() {
+        // Given: JSON payload with nested object and vars
+        String content = "{\"url\":\"http://sailthru.com\",\"title\":\"testGetContent Title\",\"date\":\"Thu Oct 03 20:18:14 UTC 2013\",\"vars\":{\"baz\":\"foo\"}}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(content);
+
+        // Then: result should be a Map with correct structure and values
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertEquals("http://sailthru.com", responseMap.get("url"));
+        assertEquals("testGetContent Title", responseMap.get("title"));
+        assertEquals("Thu Oct 03 20:18:14 UTC 2013", responseMap.get("date"));
+        assertTrue(responseMap.containsKey("vars"));
+
+        // Verify nested vars object
+        Object varsObj = responseMap.get("vars");
+        assertTrue(varsObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> varsMap = (Map<String, Object>) varsObj;
+        assertEquals("foo", varsMap.get("baz"));
+    }
+
+    @Test
+    public void testParseResponseWithImages() {
+        // Given: JSON payload with nested images structure
+        String images = "{\"images\":{\"full\":{\"url\":\"https://images.google.com/abc\"},\"thumb\":{\"url\":\"https://images.google.com/def\"}}}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(images);
+
+        // Then: result should be a Map with nested image objects
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertTrue(responseMap.containsKey("images"));
+
+        // Verify nested images object
+        Object imagesObj = responseMap.get("images");
+        assertTrue(imagesObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> imagesMap = (Map<String, Object>) imagesObj;
+
+        assertTrue(imagesMap.containsKey("full"));
+        assertTrue(imagesMap.containsKey("thumb"));
+
+        // Verify full image structure
+        Object fullObj = imagesMap.get("full");
+        assertTrue(fullObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fullMap = (Map<String, Object>) fullObj;
+        assertEquals("https://images.google.com/abc", fullMap.get("url"));
+
+        // Verify thumb image structure
+        Object thumbObj = imagesMap.get("thumb");
+        assertTrue(thumbObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> thumbMap = (Map<String, Object>) thumbObj;
+        assertEquals("https://images.google.com/def", thumbMap.get("url"));
+    }
+
+    @Test
+    public void testParseResponseWithLocation() {
+        // Given: JSON payload with array of coordinates
+        String location = "{\"location\":[40.256,-74.1239]}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(location);
+
+        // Then: result should be a Map with location array
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertTrue(responseMap.containsKey("location"));
+
+        // Verify location array
+        Object locationObj = responseMap.get("location");
+        assertTrue(locationObj instanceof List);
+
+        @SuppressWarnings("unchecked")
+        List<Object> locationList = (List<Object>) locationObj;
+
+        assertEquals(2, locationList.size());
+        assertTrue(locationList.contains(40.256));
+        assertTrue(locationList.contains(-74.1239));
+    }
+
+    @Test
+    public void testParseResponseWithPrice() {
+        // Given: JSON payload with simple numeric value
+        String price = "{\"price\":1200}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(price);
+
+        // Then: result should be a Map with price value
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertEquals(1200.0, responseMap.get("price"));
+    }
+
+    @Test
+    public void testParseResponseWithComplexNestedStructure() {
+        // Given: JSON payload combining all data types
+        String complexJson = "{\n" +
+                "                \"url\":\"http://example.com\",\n" +
+                "                \"images\":{\"full\":{\"url\":\"https://example.com/image.jpg\"}},\n" +
+                "                \"location\":[40.256,-74.1239],\n" +
+                "                \"price\":999.99,\n" +
+                "                \"metadata\":{\"key\":\"value\"}\n" +
+                "                }";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(complexJson);
+
+        // Then: result should correctly handle all nested structures
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertEquals("http://example.com", responseMap.get("url"));
+        assertEquals(999.99, responseMap.get("price"));
+        assertTrue(responseMap.containsKey("images"));
+        assertTrue(responseMap.containsKey("location"));
+        assertTrue(responseMap.containsKey("metadata"));
+    }
+
+    @Test
+    public void testParseResponseWithEmptyJson() {
+        // Given: Empty JSON object
+        String emptyJson = "{}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(emptyJson);
+
+        // Then: result should be an empty Map
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertTrue(responseMap.isEmpty());
+    }
+
+    @Test
+    public void testParseResponseReturnsMap() {
+        // Given: Valid JSON payload
+        String json = "{\"key\":\"value\",\"number\":42}";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(json);
+
+        // Then: result type should be Map
+        assertTrue(result instanceof Map);
+    }
+
+    @Test
+    public void testParseResponseWithMalformedJson() {
+        // Given: Malformed JSON payload
+        String malformedJson = "{\"key\":\"value\"";
+
+        // When/Then: parseResponse should throw an exception
+        boolean exceptionThrown = false;
+        try {
+            jsonHandler.parseResponse(malformedJson);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        assertTrue("Expected an exception to be thrown for malformed JSON", exceptionThrown);
+    }
+
+    @Test
+    public void testGetFormat() {
+        // Given: JsonHandler instance
+        // When/Then: getFormat should return "json"
+        assertEquals("json", jsonHandler.getFormat());
+    }
+
+    @Test
+    public void testParseResponseWithDifferentNumberFormats() {
+        // Given: JSON payload with various number formats
+        String numberJson = "{\n" +
+                "                \"integer\":100,\n" +
+                "                \"decimal\":123.45,\n" +
+                "                \"negative\":-99,\n" +
+                "                \"scientific\":1.23E+3\n" +
+                "                }";
+
+        // When: parseResponse is called
+        Object result = jsonHandler.parseResponse(numberJson);
+
+        // Then: all number formats should be parsed correctly
+        assertTrue(result instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseMap = (Map<String, Object>) result;
+
+        assertEquals(100.0, responseMap.get("integer"));
+        assertEquals(123.45, responseMap.get("decimal"));
+        assertEquals(-99.0, responseMap.get("negative"));
+    }
+
+}


### PR DESCRIPTION
This upgrade gson to 2.13.2 and remove the previous deprecated workaround which is now breaking with "Cannot override built-in adapter for class java.lang.Object" since the release of 2.12.0 on January 29, 2025 (see https://github.com/google/gson/issues/2787) 

The target and source bytecode is now java 8 since jdk 6 and 7 are not available anymore in jdk 21 or 25 and gson 2.12.1+ target is java 8

Unit test was added.